### PR TITLE
Feat/tr5026/acs action update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4]
+        php: [7.4]
         coverage: ["true"]
         include:
         - php: 8.0
@@ -39,7 +39,7 @@ jobs:
     - name: Psalm
       run: |
         ./vendor/bin/psalm --shepherd
-    
+
     - name: Coveralls
       if: ${{ matrix.coverage == 'true' }}
       env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
         coverage: ["true"]
         include:
-        - php: 8.0
+        - php: 8.2
           coverage: "false" # PHPUnit 8.5.14 doesn't support code coverage under PHP 8
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,9 +9,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [7.2, 7.3, 7.4]
         coverage: ["true"]
         include:
+        - php: 8.0
+          coverage: "false" # PHPUnit 8.5.14 doesn't support code coverage under PHP 8
+        - php: 8.1
+          coverage: "false" # PHPUnit 8.5.14 doesn't support code coverage under PHP 8
         - php: 8.2
           coverage: "false" # PHPUnit 8.5.14 doesn't support code coverage under PHP 8
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-only",
     "require": {
-        "php": ">=7.4.0",
+        "php": ">=7.2.0",
         "ext-json": "*",
         "oat-sa/lib-lti1p3-core": "^6.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "GPL-2.0-only",
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.4.0",
         "ext-json": "*",
         "oat-sa/lib-lti1p3-core": "^6.2"
     },

--- a/src/Factory/AcsControlFactory.php
+++ b/src/Factory/AcsControlFactory.php
@@ -56,7 +56,8 @@ class AcsControlFactory implements AcsControlFactoryInterface
                 [
                     'title' => $resourceLinkData['title'] ?? null,
                     'text' => $resourceLinkData['description'] ?? null,
-                ]);
+                ]
+            );
 
             $userData = $data['user'] ?? null;
 

--- a/src/Factory/AcsControlFactory.php
+++ b/src/Factory/AcsControlFactory.php
@@ -94,8 +94,8 @@ class AcsControlFactory implements AcsControlFactoryInterface
                 throw new InvalidArgumentException('Missing mandatory incident_time');
             }
 
-            $extraTime = $data['extra_time'] ?? null;
-            $incidentSeverity = $data['incident_severity'] ?? null;
+            $extraTime = isset($data['extra_time']) ? (int)$data['extra_time'] : null;
+            $incidentSeverity = isset($data['incident_severity']) ? (float)$data['incident_severity'] : null;
 
             return new AcsControl(
                 $resourceLink,
@@ -104,8 +104,8 @@ class AcsControlFactory implements AcsControlFactoryInterface
                 new Carbon($incidentTime),
                 $attemptNumber,
                 $issuerIdentifier,
-                $extraTime ? intval($extraTime) : null,
-                $incidentSeverity ? floatval($incidentSeverity) : null,
+                $extraTime,
+                $incidentSeverity,
                 $data['reason_code'] ?? null,
                 $data['reason_msg'] ?? null
             );

--- a/src/Factory/AcsControlResultFactory.php
+++ b/src/Factory/AcsControlResultFactory.php
@@ -40,8 +40,8 @@ class AcsControlResultFactory implements AcsControlResultFactoryInterface
             throw new LtiException('Cannot create ACS control result: Invalid status');
         }
 
-        $extraTime = $data['extra_time'] ?? null;
+        $extraTime = isset($data['extra_time']) ? (int)$data['extra_time'] : null;
 
-        return new AcsControlResult($status, $extraTime ? intval($extraTime) : null);
+        return new AcsControlResult($status, $extraTime);
     }
 }

--- a/src/Model/AcsControl.php
+++ b/src/Model/AcsControl.php
@@ -238,7 +238,9 @@ class AcsControl implements AcsControlInterface
                 'reason_code' => $this->reasonCode,
                 'reason_msg' => $this->reasonMessage,
             ],
-            static fn($element) => $element !== null
+            static function ($element) {
+                return $element !== null;
+            }
         );
     }
 }

--- a/src/Model/AcsControl.php
+++ b/src/Model/AcsControl.php
@@ -237,7 +237,8 @@ class AcsControl implements AcsControlInterface
                 'incident_severity' => $this->incidentSeverity,
                 'reason_code' => $this->reasonCode,
                 'reason_msg' => $this->reasonMessage,
-            ]
+            ],
+            static fn($element) => $element !== null
         );
     }
 }

--- a/src/Model/AcsControlResult.php
+++ b/src/Model/AcsControlResult.php
@@ -79,7 +79,8 @@ class AcsControlResult implements AcsControlResultInterface
             [
                 'status' => $this->status,
                 'extra_time' => $this->extraTime,
-            ]
+            ],
+            static fn($element) => $element !== null
         );
     }
 }

--- a/src/Model/AcsControlResult.php
+++ b/src/Model/AcsControlResult.php
@@ -80,7 +80,9 @@ class AcsControlResult implements AcsControlResultInterface
                 'status' => $this->status,
                 'extra_time' => $this->extraTime,
             ],
-            static fn($element) => $element !== null
+            static function($element) {
+                return $element !== null;
+            }
         );
     }
 }

--- a/tests/Unit/Factory/AcsControlFactoryTest.php
+++ b/tests/Unit/Factory/AcsControlFactoryTest.php
@@ -80,6 +80,86 @@ class AcsControlFactoryTest extends TestCase
         $this->assertEquals('message', $result->getReasonMessage());
     }
 
+    public function testCreateSuccessWithZeroExtraTimeAndIncidentSeverity(): void
+    {
+        $date = Carbon::now();
+
+        $result = $this->subject->create(
+            [
+                'user' => [
+                    'iss' => 'issuerIdentifier',
+                    'sub' => 'userIdentifier',
+                ],
+                'resource_link' => [
+                    'id' => 'resourceLinkIdentifier',
+                    'title' => 'resourceLinkTitle',
+                    'description' => 'resourceLinkDescription',
+                ],
+                'attempt_number' => 1,
+                'action' => AcsControlInterface::ACTION_UPDATE,
+                'extra_time' => 0,
+                'incident_time' => $date->format(DATE_ATOM),
+                'incident_severity' => 0,
+                'reason_code' => 'code',
+                'reason_msg' => 'message',
+            ]
+        );
+
+        $this->assertInstanceOf(AcsControlInterface::class, $result);
+
+        $this->assertEquals('resourceLinkIdentifier', $result->getResourceLink()->getIdentifier());
+        $this->assertEquals('resourceLinkTitle', $result->getResourceLink()->getTitle());
+        $this->assertEquals('resourceLinkDescription', $result->getResourceLink()->getText());
+        $this->assertEquals('issuerIdentifier', $result->getIssuerIdentifier());
+        $this->assertEquals('userIdentifier', $result->getUserIdentifier());
+        $this->assertEquals(1, $result->getAttemptNumber());
+        $this->assertEquals(AcsControlInterface::ACTION_UPDATE, $result->getAction());
+        $this->assertEquals(0, $result->getExtraTime());
+        $this->assertEquals($date->format(DATE_ATOM), $result->getIncidentTime()->format(DATE_ATOM));
+        $this->assertEquals(0, $result->getIncidentSeverity());
+        $this->assertEquals('code', $result->getReasonCode());
+        $this->assertEquals('message', $result->getReasonMessage());
+    }
+
+    public function testCreateSuccessWithoutExtraTimeAndIncidentSeverity(): void
+    {
+        $date = Carbon::now();
+
+        $result = $this->subject->create(
+            [
+                'user' => [
+                    'iss' => 'issuerIdentifier',
+                    'sub' => 'userIdentifier',
+                ],
+                'resource_link' => [
+                    'id' => 'resourceLinkIdentifier',
+                    'title' => 'resourceLinkTitle',
+                    'description' => 'resourceLinkDescription',
+                ],
+                'attempt_number' => 1,
+                'action' => AcsControlInterface::ACTION_UPDATE,
+                'incident_time' => $date->format(DATE_ATOM),
+                'reason_code' => 'code',
+                'reason_msg' => 'message',
+            ]
+        );
+
+        $this->assertInstanceOf(AcsControlInterface::class, $result);
+
+        $this->assertEquals('resourceLinkIdentifier', $result->getResourceLink()->getIdentifier());
+        $this->assertEquals('resourceLinkTitle', $result->getResourceLink()->getTitle());
+        $this->assertEquals('resourceLinkDescription', $result->getResourceLink()->getText());
+        $this->assertEquals('issuerIdentifier', $result->getIssuerIdentifier());
+        $this->assertEquals('userIdentifier', $result->getUserIdentifier());
+        $this->assertEquals(1, $result->getAttemptNumber());
+        $this->assertEquals(AcsControlInterface::ACTION_UPDATE, $result->getAction());
+        $this->assertEquals(null, $result->getExtraTime());
+        $this->assertEquals($date->format(DATE_ATOM), $result->getIncidentTime()->format(DATE_ATOM));
+        $this->assertEquals(null, $result->getIncidentSeverity());
+        $this->assertEquals('code', $result->getReasonCode());
+        $this->assertEquals('message', $result->getReasonMessage());
+    }
+
     /**
      * @dataProvider provideFailingData
      */


### PR DESCRIPTION
# [TR-5026](https://oat-sa.atlassian.net/browse/TR-5026)

## Summary
This PR aim to add possibility to create, serialize and deserialize ACS entity with empty not null values

[TR-5026]: https://oat-sa.atlassian.net/browse/TR-5026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ